### PR TITLE
triming whitespace after magic string so filename is correct.

### DIFF
--- a/R/add_tables.R
+++ b/R/add_tables.R
@@ -28,7 +28,7 @@
 #' )
 #' }
 add_tables <- function(docx_in, docx_out, tables_path, debug = F) {
-  log4r::debug(.le$logger, "Starting add_tables_by_magic_string function")
+  log4r::debug(.le$logger, "Starting add_tables function")
   tictoc::tic()
 
   if (!file.exists(docx_in)) {
@@ -69,7 +69,7 @@ add_tables <- function(docx_in, docx_out, tables_path, debug = F) {
 
     if (length(matches) > 0) {
       log4r::info(.le$logger, paste0("Found magic string: ", matches[1], " in paragraph ", i))
-      table_name <- gsub("\\{rpfy\\}:", "", matches[1]) # Remove "{rpfy}:"
+      table_name <- gsub("\\{rpfy\\}:", "", matches[1]) |> trimws() # Remove "{rpfy}:"
       table_file <- file.path(tables_path, table_name)
       #if (tools::file_ext(table_file) %in% c("RDS", "csv")) {
 

--- a/inst/scripts/add_figure.py
+++ b/inst/scripts/add_figure.py
@@ -20,7 +20,7 @@ def add_figure(docx_in, docx_out, figure_dir, fig_width, fig_height):
                 print(f"Duplicate figure names found in paragraph {i+1}.")
             for match in matches:
                 # Extract the image directory from the match
-                figure_name = match.replace("{rpfy}:", "") 
+                figure_name = match.replace("{rpfy}:", "").strip()
                 found_magic_strings.append(figure_name)
 
                 image_path = os.path.join(figure_dir, figure_name)

--- a/inst/scripts/add_figure_footnotes.py
+++ b/inst/scripts/add_figure_footnotes.py
@@ -26,7 +26,7 @@ def add_figure_footnotes(docx_in, docx_out, figure_dir, footnotes_yaml):
         if matches:
             for match in matches:
                 # Generalized extraction of the figure name
-                figure_name = match.replace("{rpfy}:", "")
+                figure_name = match.replace("{rpfy}:", "").strip()
                 if figure_name in os.listdir(figure_dir):
 
                     object_name, extension = os.path.splitext(figure_name)

--- a/inst/scripts/add_table_footnotes.py
+++ b/inst/scripts/add_table_footnotes.py
@@ -26,7 +26,7 @@ def add_table_footnotes(docx_in, docx_out, table_dir, footnotes_yaml):
         if matches:
             for match in matches:
                 # Generalized extraction of the figure name
-                table_name = match.replace("{rpfy}:", "")
+                table_name = match.replace("{rpfy}:", "").strip()
                 if table_name in os.listdir(table_dir):
                     object_name, extension = os.path.splitext(table_name)
                     metadata_file = os.path.join(table_dir, f"{object_name}_{extension[1::]}_metadata.json")


### PR DESCRIPTION
if a space was trailing the magic string in a word document the file name parsed from the magic string contained the space so files were not found. I added trimws() or .strip() to the relevant add_tables, add_figures, add_x_footnotes functions to fix.

Below are images of a template with spaces after each reportifyr magic string.
![1_template_fig2_space](https://github.com/user-attachments/assets/1d5d75aa-85e4-48a2-9c04-41244b7136fd)
![2_template_fig3_space](https://github.com/user-attachments/assets/07fff97d-d03f-4855-b86a-a5d99745e903)
![3_template_tab1_space](https://github.com/user-attachments/assets/2c65072a-12b8-4f04-bf6a-7bd2284587bd)
![4_template_tab2_space](https://github.com/user-attachments/assets/eeb51607-8483-4eaf-8023-f58c6f4c8206)

And below is the resulting draft from `build_report` showing that no tables or figures were inserted.
![5_draft_fig2_space_prefix](https://github.com/user-attachments/assets/d549d44c-2151-4b74-891f-137c2b534463)
![6_draft_fig3_space_prefix](https://github.com/user-attachments/assets/d2605038-a82d-4744-82da-5db229a62383)
![7_draft_tab1_space_prefix](https://github.com/user-attachments/assets/c10e7d60-e270-4be0-bafc-a18205a62a56)
![8_draft_tab2_space_prefix](https://github.com/user-attachments/assets/70f7ece2-7c19-42ad-bb55-7eb7a005d851)

After implementing the trimws() and .strip() the tables and figures are now correctly added with footnotes.
<img width="730" alt="9_draft_fig2_space_postfix" src="https://github.com/user-attachments/assets/3963dbea-074a-4b9e-9618-7f767ea30cbc">
<img width="724" alt="10_draft_fig3_space_postfix" src="https://github.com/user-attachments/assets/5f0eda15-0769-4fa6-9cbd-1d35b5d85ffb">
<img width="758" alt="11_draft_tab1_space_postfix" src="https://github.com/user-attachments/assets/05d2a1cd-57ea-4089-965d-0d80f2393c13">
<img width="735" alt="12_draft_tab2_space_postfix" src="https://github.com/user-attachments/assets/1213acf4-9668-499b-884e-8d80c944370e">

Additionally, here is a report built from a template with no spaces after the magic string showing the figures are still incorporated correctly.
<img width="740" alt="13_draft_fig2_nospace_postfix" src="https://github.com/user-attachments/assets/e7958ddd-053c-498c-8619-9cf014aa3b70">
