### PR TITLE
updated uv path determinatino with uv v0.5.0 installing to ~/.local/b…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reportifyr
 Title: Create reproducible reports with quarto and word 
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("Jacob", "Dumbleton", , "jacob@a2-ai.com", role = c("aut", "cre")),
     person("Matthew", "Smith", , "matthews@a2-ai.com", role = "aut"),

--- a/R/add_footnotes.R
+++ b/R/add_footnotes.R
@@ -122,11 +122,7 @@ add_footnotes <- function(docx_in,
     stop("Create virtual environment with initialize_python")
   }
 
-  uv_path <- normalizePath("~/.cargo/bin/uv", mustWork = FALSE)
-  if (!file.exists(uv_path)) {
-    log4r::error(.le$logger, "uv not found. Please install with initialize_python")
-    stop("Please install uv with initialize_python")
-  }
+  uv_path <- get_uv_path()
 
   log4r::debug(.le$logger, "Running figure footnotes script")
   fig_results <- tryCatch({

--- a/R/add_plots.R
+++ b/R/add_plots.R
@@ -98,11 +98,7 @@ add_plots <- function(docx_in,
     stop("Create virtual environment with initialize_python")
   }
 
-  uv_path <- normalizePath("~/.cargo/bin/uv", mustWork = FALSE)
-  if (!file.exists(uv_path)) {
-    log4r::error(.le$logger, "uv not found. Please install with initialize_python")
-    stop("Please install uv with initialize_python")
-  }
+  uv_path <- get_uv_path()
 
   log4r::debug(.le$logger, "Running add plots script")
   result <- tryCatch({

--- a/R/initialize_python.R
+++ b/R/initialize_python.R
@@ -38,18 +38,18 @@ initialize_python <- function() {
     args <- c(args, getOption("python.version"))
     log4r::info(.le$logger, paste0("Using specified python version: ", getOption("python.version")))
   }
-  
-  uv_path <- normalizePath("~/.cargo/bin/uv", mustWork = FALSE)
+
+  uv_path <- get_uv_path()
 
   if (!dir.exists(file.path(args[[1]], ".venv"))) {
     log4r::debug(.le$logger, "Creating new virtual environment")
-    
+
     result <- processx::run(
       command = cmd,
       args = args
     )
     log4r::info(.le$logger, paste("Virtual environment created at: ", file.path(args[[1]], ".venv")))
-    
+
     args_name <- c("venv_dir", "python-docx.version", "pyyaml.version", "python.version")
     pyvers <- get_py_version(getOption("venv_dir"))
     if (!is.null(pyvers)) {
@@ -59,7 +59,7 @@ initialize_python <- function() {
       args <- c(args, "")
       log4r::warn(.le$logger, "Python version could not be detected")
     }
-    
+
     message(paste(
       "Creating python virtual environment with the following settings:\n",
       paste0("\t", args_name, ": ", args, collapse = "\n")

--- a/R/initialize_python.R
+++ b/R/initialize_python.R
@@ -34,6 +34,13 @@ initialize_python <- function() {
     log4r::info(.le$logger, "Using default pyyaml version: 6.0.2")
   }
 
+  if (!is.null(getOption("uv.version"))) {
+    args <- c(args, getOption("uv.version"))
+  } else {
+    args <- c(args, "0.5.1")
+    log4r::info(.le$logger, "Using default uv version: 0.5.1")
+  }
+
   if (!is.null(getOption("python.version"))) {
     args <- c(args, getOption("python.version"))
     log4r::info(.le$logger, paste0("Using specified python version: ", getOption("python.version")))

--- a/R/remove_bookmarks.R
+++ b/R/remove_bookmarks.R
@@ -108,11 +108,7 @@ remove_bookmarks <- function(docx_in,
       stop("Create virtual environment with initialize_python")
     }
 
-    uv_path <- normalizePath("~/.cargo/bin/uv", mustWork = FALSE)
-    if (!file.exists(uv_path)) {
-      log4r::error(.le$logger, "uv not found. Please install with initialize_python")
-      stop("Please install uv with initialize_python")
-    }
+    uv_path <- get_uv_path()
 
     script <- system.file("scripts/remove_bookmarks.py", package = "reportifyr")
     args <- c("run", script, "-i", docx_in, "-o", docx_out)

--- a/R/remove_magic_strings.R
+++ b/R/remove_magic_strings.R
@@ -77,7 +77,6 @@ remove_magic_strings <- function(docx_in, docx_out) {
     stop(paste("The file must be a docx file not:", tools::file_ext(docx_out)))
   }
 
-
   if (interactive()) {
     log4r::info(.le$logger, "Prompting user for confirmation to remove bookmarks.")
     continue <- readline("This will remove magic strings from the document. This severs link between the document and reportifyr. Are you sure you want to continue? [Y/n]\n")
@@ -107,11 +106,7 @@ remove_magic_strings <- function(docx_in, docx_out) {
       stop("Create virtual environment with initialize_python")
     }
 
-    uv_path <- normalizePath("~/.cargo/bin/uv", mustWork = FALSE)
-    if (!file.exists(uv_path)) {
-      log4r::error(.le$logger, "uv not found. Please install with initialize_python")
-      stop("Please install uv with initialize_python")
-    }
+    uv_path <- get_uv_path()
 
     script <- system.file("scripts/remove_magic_strings.py", package = "reportifyr")
     args <- c("run", script, "-i", docx_in, "-o", docx_out)

--- a/R/remove_tables_figures_footnotes.R
+++ b/R/remove_tables_figures_footnotes.R
@@ -53,13 +53,9 @@ remove_tables_figures_footnotes <- function(docx_in,
     log4r::error(.le$logger, "Virtual environment not found. Please initialize with initialize_python.")
     stop("Create virtual environment with initialize_python")
   }
-  
-  uv_path <- normalizePath("~/.cargo/bin/uv", mustWork = FALSE)
-  if (!file.exists(uv_path)) {
-    log4r::error(.le$logger, "uv not found. Please install with initialize_python")
-    stop("Please install uv with initialize_python")
-  }
-  
+
+  uv_path <- get_uv_path()
+
   notes_script <- system.file("scripts/remove_footnotes.py", package = "reportifyr")
   notes_args <- c("run", notes_script, "-i", docx_in, "-o", docx_out)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -106,3 +106,25 @@ get_packages <- function() {
 
   return(pkgs_metadata)
 }
+
+
+#' Gets the path to uv -- pre v0.5.0 installed to /.cargo/bin post v0.5.0 to /.local/bin
+#'
+#' @return path to uv
+#'
+#' @keywords internal
+#' @noRd
+get_uv_path <- function() {
+  uv_paths <- c(normalizePath("~/.local/bin/uv", mustWork = FALSE),
+                normalizePath("~/.cargo/bin/uv", mustWork = FALSE))
+
+  # Find the first existing path, preferring ~/.local/bin/uv
+  uv_path <- uv_paths[file.exists(uv_paths)][1]
+
+  if (is.null(uv_path)) {
+    log4r::error(.le$logger, "uv not found. Please install with initialize_python")
+    stop("Please install uv with initialize_python")
+  } else {
+    return(uv_path)
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,11 +29,18 @@ reportifyr_options_message <- function() {
     set_options <- c(set_options, paste("venv_dir:", root))
   }
   # NICE TO HAVES
-  pyversion <- getOption("python_version")
+  uvversion <- getOption("uv.version")
+  if (is.null(uvversion)) {
+    optional_options <- c(optional_options, "options('uv.version') is not set. Default is 0.5.1")
+  } else {
+    set_options <- c(set_options, paste("uv.version:", uvversion))
+  }
+
+  pyversion <- getOption("python.version")
   if (is.null(pyversion)) {
     optional_options <- c(optional_options, "options('python.version') is not set. Default is system version")
   } else {
-    set_options <- c(set_options, paste("python_version:", pyversion))
+    set_options <- c(set_options, paste("python.version:", pyversion))
   }
 
   docx_vers <- getOption("python-docx.version")

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,12 +1,10 @@
 url: https://a2-ai.github.io/reportifyr/
-
 template:
   bootstrap: 5
   bslib:
-    bg: "#FFFFFF"
-    fg: "#63666A"
-    primary: "#1E63AF"
-
+    bg: '#FFFFFF'
+    fg: '#63666A'
+    primary: '#1E63AF'
 navbar:
   title: reportifyr
   bg: primary
@@ -41,7 +39,6 @@ navbar:
     github:
       icon: fa-github fa-lg
       href: https://github.com/a2-ai/reportifyr
-
 reference:
 - title: Set-up Functions
   contents:
@@ -77,5 +74,5 @@ reference:
   - validate_object
   - toggle_logger
 - title: Reportifyr Summary
-  contents:
-  - reportifyr
+  contents: reportifyr
+

--- a/inst/scripts/uv_setup.sh
+++ b/inst/scripts/uv_setup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# uv_setup.sh venv_directiory python-docx_version pyyaml_version python_version
+# uv_setup.sh venv_directory python-docx_version pyyaml_version uv_version [python_version]
 
-#check if uv is installed.
+# Check if uv is installed.
 if ! command -v uv &> /dev/null; then
-  echo "'uv' is not installed. Installing..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+  echo "'uv' is not installed. Installing version $4..."
+  curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/astral-sh/uv/releases/download/$4/uv-installer.sh" | sh
 fi
 
 if [[ ":$PATH:" != *":$HOME/.cargo/bin:"* ]]; then
@@ -21,10 +21,10 @@ source $HOME/.bashrc
 
 if [ ! -d "$1/.venv" ]; then
   echo "Creating venv at $1/.venv"
-  if [ -n "$4" ]; then
-    uv venv "$1/.venv" --python="$4"  # Use the version provided in $4
+  if [ -n "$5" ]; then
+    uv venv "$1/.venv" --python="$5"  # Use the Python version provided in $5
   else
-    uv venv "$1/.venv"  # Default version
+    uv venv "$1/.venv"  # Default version if $5 is not provided
   fi
 fi
 
@@ -39,6 +39,7 @@ if ! python -c "import docx" &> /dev/null; then
   fi
 fi
 
+# Check if pyyaml is installed, install it if not
 if ! python -c "import yaml" &> /dev/null; then
   if [ -n "$3" ]; then
     uv pip install "pyyaml==$3"

--- a/man/build_report.Rd
+++ b/man/build_report.Rd
@@ -6,7 +6,7 @@
 \usage{
 build_report(
   docx_in,
-  docx_out,
+  docx_out = NULL,
   figures_path,
   tables_path,
   standard_footnotes_yaml = NULL,

--- a/man/reportifyr.Rd
+++ b/man/reportifyr.Rd
@@ -117,7 +117,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Fenando Carreno \email{fernando.o.carreno@gsk.com} [contributor]
+  \item Fernando Carreno \email{fernando.o.carreno@gsk.com} [contributor]
   \item Kashyap Patel \email{kashyap.x.patel@gsk.com} [contributor]
   \item Maxwell Chirehwa \email{maxwell.t.chirehwa@gsk.com} [contributor]
   \item Wesley Cummings \email{wes@a2-ai.com} [contributor]


### PR DESCRIPTION
…in/ instead of ~/.cargo/bin.

As of v0.5.0 of uv, uv is installed to ~/.local/bin instead of ~/.cargo/bin. This would cause issues in reportifyr for most functions. In this PR we introduce a `get_uv_path()` function to utils.R to determine if ~/.local/bin/uv or ~/.cargo/bin/uv exists and returns the path found with a preference to ~/.local/bin/uv if they both exist. 

From https://github.com/astral-sh/uv/releases

> -  Use XDG (i.e. ~/.local/bin) instead of the Cargo home directory in the installer (#8420)
>
>Previously, uv's installer used $CARGO_HOME or ~/.cargo/bin for its target install directory. It's been a longstanding complaint that uv uses this directory, as there's no relationship to Cargo. Now, uv will be installed into $XDG_BIN_HOME, $XDG_DATA_HOME/../bin, or ~/.local/bin (in that order). Note that $UV_INSTALL_DIR can always be used to override the target directory. Upgrading with uv self update will not move uv to the new install directory.