### PR TITLE
if the {rpfy}: string is in a separate paragraph from the figure, it …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reportifyr
 Title: Create reproducible reports with quarto and word 
-Version: 0.2.2
+Version: 0.2.4
 Authors@R: c(
     person("Jacob", "Dumbleton", , "jacob@a2-ai.com", role = c("aut", "cre")),
     person("Matthew", "Smith", , "matthews@a2-ai.com", role = "aut"),

--- a/R/add_tables.R
+++ b/R/add_tables.R
@@ -71,9 +71,7 @@ add_tables <- function(docx_in, docx_out, tables_path, debug = F) {
       log4r::info(.le$logger, paste0("Found magic string: ", matches[1], " in paragraph ", i))
       table_name <- gsub("\\{rpfy\\}:", "", matches[1]) |> trimws() # Remove "{rpfy}:"
       table_file <- file.path(tables_path, table_name)
-      #if (tools::file_ext(table_file) %in% c("RDS", "csv")) {
 
-      #}
       # Check if the file exists
       if (file.exists(table_file)) {
         found_matches <- TRUE

--- a/R/save_rds_with_metadata.R
+++ b/R/save_rds_with_metadata.R
@@ -44,7 +44,8 @@ save_rds_with_metadata <- function(object,
     meta_type = meta_type,
     equations = meta_equations,
     notes = meta_notes,
-    abbrevs = meta_abbrevs
+    abbrevs = meta_abbrevs,
+    table1_format = table1_format
   )
 
   save_rtf(object = object, file = file, table1_format = table1_format)

--- a/R/write_csv_with_metadata.R
+++ b/R/write_csv_with_metadata.R
@@ -45,7 +45,8 @@ write_csv_with_metadata <- function(object,
     meta_type = meta_type,
     equations = meta_equations,
     notes = meta_notes,
-    abbrevs = meta_abbrevs
+    abbrevs = meta_abbrevs,
+    table1_format = table1_format
   )
 
   save_rtf(object = object, file = file, table1_format = table1_format)

--- a/inst/scripts/remove_figures.py
+++ b/inst/scripts/remove_figures.py
@@ -3,12 +3,20 @@ from docx import Document
 
 def remove_figures(docx_in, docx_out):
     doc = Document(docx_in)
+    paragraphs = doc.paragraphs
     namespace = '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}'
-
-    for paragraph in doc.paragraphs:
+    
+    for i, paragraph in enumerate(paragraphs):
         if paragraph.text.startswith('{rpfy}:'):
-            for drawing in paragraph._element.xpath(f'.//w:drawing'):
-                drawing.getparent().remove(drawing)
+            if any(paragraph._element.xpath('.//w:drawing')):
+                for drawing in paragraph._element.xpath('.//w:drawing'):
+                    drawing.getparent().remove(drawing)
+                    
+            elif i + 1 < len(paragraphs):
+                next_paragraph = paragraphs[i + 1]
+                if not next_paragraph.text.strip() and next_paragraph._element.xpath('.//w:drawing'):
+                    next_paragraph._element.getparent().remove(next_paragraph._element)
+        
 
     doc.save(docx_out)
     print(f"Processed file saved at '{docx_out}'.")


### PR DESCRIPTION
…was not being removed. Updated remove_figure to search the paragraph with {rpfy}: remove the drawing if it's there, if not go to the next paragraph and remove it there if it exists. Additionally, table1_format argument was not being passed from save_rds_with_metadata/write_csv_with_metadata to write_object_metadata.

v0.2.3: Table1 formatting was not applied
![image (2)](https://github.com/user-attachments/assets/bce5cbda-0d7f-4e66-9e86-1ee8df37a7ad)
v0.2.4: Table1 formatting is correctly applied
![image (3)](https://github.com/user-attachments/assets/c954a69d-ce0d-42c0-ae79-b2ddd6390523)

The following figure would not be removed due to {rpfy}: string being in different paragraph. 
<img width="558" alt="Screenshot 2024-11-13 at 8 25 52 AM" src="https://github.com/user-attachments/assets/6cab7a2b-7016-4aed-94eb-05c586994dd8">
<img width="1259" alt="Screenshot 2024-11-13 at 8 29 25 AM" src="https://github.com/user-attachments/assets/bff898d5-b282-47d6-99ae-bc048c439b9f">
The update successfully removes this figure.
<img width="1210" alt="Screenshot 2024-11-13 at 8 31 15 AM" src="https://github.com/user-attachments/assets/0a3fc546-e0ff-42bd-bf2f-de2fc7bf7511">



