### PR TITLE
Config logic for 0.3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reportifyr
 Title: Reproducible Reporting Made Simple with R
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person("Jacob", "Dumbleton", , "jacob@a2-ai.com", role = c("aut", "cre")),
     person("Matthew", "Smith", , "matthews@a2-ai.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# reportifyr 0.3.1
+## Minor Improvements
+
+* If `config_yaml` is left `NULL` for the following functions, a default `config.yaml` file bundled with `reportifyr` is used instead:
+  * `add_footnotes()`
+  * `add_plots()`
+  * `add_tables()`
+  * `build_report()`
+  * `finalize_document()`
+  * `remove_tables_figures_footnotes()`
+
+* `validate_input_args()` and `validate_alt_text_magic_strings()` no longer take a `config_yaml` argument.
+
+* Function and argument descriptions introduced or expanded on in 0.3.0 have been updated for clarity and understanding.
+  
 # reportifyr 0.3.0
 ## New Features
 

--- a/R/add_footnotes.R
+++ b/R/add_footnotes.R
@@ -78,7 +78,7 @@ add_footnotes <- function(
     browser()
   }
 
-  validate_input_args(docx_in, docx_out, config_yaml)
+  validate_input_args(docx_in, docx_out)
   validate_docx(docx_in, config_yaml)
   log4r::info(.le$logger, paste0("Output document path set: ", docx_out))
 
@@ -142,7 +142,7 @@ add_footnotes <- function(
 
   if (!is.null(config_yaml)) {
     if (!validate_config(config_yaml)) {
-      stop("Invalid confi yaml. Please fix")
+      stop("Invalid config yaml. Please fix")
     }
     log4r::info(
       .le$logger,
@@ -158,11 +158,10 @@ add_footnotes <- function(
       paste0("Using default config file: ", config_yaml)
     )
   }
-  if (!is.null(config_yaml)) {
-    log4r::info(.le$logger, "Adding config.yaml to args")
-    fig_args <- c(fig_args, "-c", config_yaml)
-    tab_args <- c(tab_args, "-c", config_yaml)
-  }
+  log4r::info(.le$logger, "Adding config.yaml to args")
+  fig_args <- c(fig_args, "-c", config_yaml)
+  tab_args <- c(tab_args, "-c", config_yaml)
+
   paths <- get_venv_uv_paths()
   log4r::debug(.le$logger, "Running figure footnotes script")
   tryCatch(

--- a/R/add_plots.R
+++ b/R/add_plots.R
@@ -4,7 +4,7 @@
 #' @param docx_in The file path to the input `.docx` file.
 #' @param docx_out The file path to the output `.docx` file to save to.
 #' @param figures_path The file path to the figures directory.
-#' @param config_yaml The path to config.yaml file that controls figure dimensions
+#' @param config_yaml The file path to the `config.yaml`. Default is `NULL`, a default `config.yaml` bundled with the `reportifyr` package is used.
 #' @param fig_width A global controller. The figure width in inches. Default is `NULL`. If `NULL`, the width is determined by the figure's pixel dimensions.
 #' @param fig_height A global controller. The figure height in inches. Default is `NULL`. If `NULL`, the height is determined by the figure's pixel dimensions.
 #' @param debug Debug.
@@ -59,7 +59,7 @@ add_plots <- function(
     browser()
   }
 
-  validate_input_args(docx_in, docx_out, config_yaml)
+  validate_input_args(docx_in, docx_out)
   validate_docx(docx_in, config_yaml)
   log4r::info(.le$logger, paste0("Output document path set: ", docx_out))
 
@@ -85,10 +85,13 @@ add_plots <- function(
     figures_path
   )
 
-  if (!is.null(config_yaml)) {
-    args <- c(args, "-c", config_yaml)
-    log4r::info(.le$logger, paste0("config yaml set: ", config_yaml))
+  if (is.null(config_yaml)) {
+    config_yaml <- system.file("extdata", "config.yaml", package = "reportifyr")
+    log4r::info(.le$logger, paste0("using built-in config.yaml: ", config_yaml))
   }
+
+  args <- c(args, "-c", config_yaml)
+  log4r::info(.le$logger, paste0("config yaml set: ", config_yaml))
 
   if (!is.null(fig_width)) {
     args <- c(args, "-w", fig_width)

--- a/R/add_plots_alt_text.R
+++ b/R/add_plots_alt_text.R
@@ -1,8 +1,8 @@
-#' add_plots_alt_text()
+#' Inserts alt text for figures within a Microsoft Word file.
 #'
-#' @param docx_in path to document
-#' @param docx_out path to output document with figures alt text
-#' @param debug boolean turns on browser
+#' @param docx_in The file path to the input `.docx` file.
+#' @param docx_out The file path to the output `.docx` file to save to.
+#' @param debug Debug.
 #'
 #' @export
 #'
@@ -22,7 +22,7 @@ add_plots_alt_text <- function(
     browser()
   }
 
-  validate_input_args(docx_in, docx_out, NULL)
+  validate_input_args(docx_in, docx_out)
 
   log4r::info(.le$logger, paste0("Output document path set: ", docx_out))
 

--- a/R/add_tables.R
+++ b/R/add_tables.R
@@ -4,7 +4,7 @@
 #' @param docx_in The file path to the input `.docx` file.
 #' @param docx_out The file path to the output `.docx` file to save to.
 #' @param tables_path The file path to the tables and associated metadata directory.
-#' @param config_yaml The path to config.yaml file that controls figure dimensions
+#' @param config_yaml The file path to the `config.yaml`. Default is `NULL`, a default `config.yaml` bundled with the `reportifyr` package is used.
 #' @param debug Debug.
 #'
 #' @export
@@ -45,7 +45,12 @@ add_tables <- function(
     browser()
   }
 
-  validate_input_args(docx_in, docx_out, config_yaml)
+  if (is.null(config_yaml)) {
+    config_yaml <- system.file("extdata", "config.yaml", package = "reportifyr")
+    log4r::info(.le$logger, paste0("using built-in config.yaml: ", config_yaml))
+  }
+
+  validate_input_args(docx_in, docx_out)
   validate_docx(docx_in, config_yaml)
   log4r::info(.le$logger, paste0("Output document path set: ", docx_out))
 

--- a/R/add_tables_alt_text.R
+++ b/R/add_tables_alt_text.R
@@ -1,8 +1,8 @@
-#' add_tables_alt_text
+#' Inserts alt text for tables within a Microsoft Word file.
 #'
-#' @param docx_in path to input document
-#' @param docx_out path to output document
-#' @param debug boolean for turning on debugging
+#' @param docx_in The file path to the input `.docx` file.
+#' @param docx_out The file path to the output `.docx` file to save to.
+#' @param debug Debug.
 #'
 #' @export
 #'
@@ -22,7 +22,7 @@ add_tables_alt_text <- function(
     browser()
   }
 
-  validate_input_args(docx_in, docx_out, NULL)
+  validate_input_args(docx_in, docx_out)
 
   log4r::info(.le$logger, paste0("Output document path set: ", docx_out))
 

--- a/R/build_report.R
+++ b/R/build_report.R
@@ -50,7 +50,12 @@ build_report <- function(
 ) {
   log4r::debug(.le$logger, "Starting build_report function")
 
-  validate_input_args(docx_in, docx_out, config_yaml)
+  if (is.null(config_yaml)) {
+    config_yaml <- system.file("extdata", "config.yaml", package = "reportifyr")
+    log4r::info(.le$logger, paste0("using built-in config.yaml: ", config_yaml))
+  }
+
+  validate_input_args(docx_in, docx_out)
   validate_docx(docx_in, config_yaml)
   log4r::info(.le$logger, paste0("Output document path set: ", docx_out))
 

--- a/R/finalize_document.R
+++ b/R/finalize_document.R
@@ -3,7 +3,7 @@
 #' @description Reads in a `.docx` file and returns a finalized version with magic strings and bookmarks removed.
 #' @param docx_in The file path to the input `.docx` file.
 #' @param docx_out The file path to the output `.docx` file to save to. Default is `NULL`. If `NULL`, `docx_out` is assigned `doc_dirs$doc_final` using `make_doc_dirs(docx_in = docx_in)`.
-#' @param config_yaml The file path to the `config.yaml`.
+#' @param config_yaml The file path to the `config.yaml`. Default is `NULL`, a default `config.yaml` bundled with the `reportifyr` package is used.
 #'
 #' @export
 #'
@@ -45,7 +45,7 @@
 finalize_document <- function(
   docx_in,
   docx_out = NULL,
-  config_yaml
+  config_yaml = NULL
 ) {
   tictoc::tic()
   log4r::debug(.le$logger, "Starting finalize_document function")
@@ -59,7 +59,11 @@ finalize_document <- function(
     )
   }
 
-  validate_input_args(docx_in, docx_out, config_yaml)
+  if (is.null(config_yaml)) {
+    config_yaml <- system.file("extdata", "config.yaml", package = "reportifyr")
+  }
+
+  validate_input_args(docx_in, docx_out)
   validate_docx(docx_in, config_yaml)
   log4r::info(.le$logger, paste0("Output document path set: ", docx_out))
 

--- a/R/initialize_report_project.R
+++ b/R/initialize_report_project.R
@@ -3,10 +3,10 @@
 #' @param project_dir The file path to the main project directory
 #' where the directory structure will be created.
 #' The directory must already exist; otherwise, an error will be thrown.
-#' @param report_dir_name The directory name for where reports will be saved,
-#' default NULL will use "report"
-#' @param outputs_dir_name The directory name for where artifacts will be saved,
-#' default NULL will use "OUTPUTS"
+#' @param report_dir_name The directory name for where reports will be saved.
+#' Default is `NULL`. If `NULL`, `report` will be used.
+#' @param outputs_dir_name The directory name for where artifacts will be saved.
+#' Default is `NULL`. If `NULL`, `OUTPUTS` will be used.
 #'
 #' @export
 #'

--- a/R/keep_caption_next.R
+++ b/R/keep_caption_next.R
@@ -6,7 +6,7 @@
 #' @noRd
 keep_caption_next <- function(docx_in, docx_out) {
   log4r::debug(.le$logger, "Starting keep_caption_next function")
-  validate_input_args(docx_in, docx_out, NULL)
+  validate_input_args(docx_in, docx_out)
 
   paths <- get_venv_uv_paths()
 

--- a/R/remove_bookmarks.R
+++ b/R/remove_bookmarks.R
@@ -43,7 +43,7 @@ remove_bookmarks <- function(docx_in, docx_out) {
   tictoc::tic()
   log4r::debug(.le$logger, "Starting remove_bookmarks function")
 
-  validate_input_args(docx_in, docx_out, NULL)
+  validate_input_args(docx_in, docx_out)
 
   if (interactive()) {
     log4r::info(

--- a/R/remove_magic_strings.R
+++ b/R/remove_magic_strings.R
@@ -43,7 +43,7 @@
 remove_magic_strings <- function(docx_in, docx_out) {
   tictoc::tic()
   log4r::debug(.le$logger, "Starting remove_magic_strings function")
-  validate_input_args(docx_in, docx_out, NULL)
+  validate_input_args(docx_in, docx_out)
 
   if (interactive()) {
     log4r::info(

--- a/R/remove_tables_figures_footnotes.R
+++ b/R/remove_tables_figures_footnotes.R
@@ -31,8 +31,8 @@ remove_tables_figures_footnotes <- function(
   tictoc::tic()
   log4r::debug(.le$logger, "Starting remove_tables_figures_footnotes function")
 
-  validate_input_args(docx_in, docx_out, config_yaml)
-  validate_alt_text_magic_strings(docx_in, config_yaml)
+  validate_input_args(docx_in, docx_out)
+  validate_alt_text_magic_strings(docx_in)
 
   paths <- get_venv_uv_paths()
   notes_script <- system.file(
@@ -120,10 +120,11 @@ remove_tables_figures_footnotes <- function(
   fig_script <- system.file("scripts/remove_figures.py", package = "reportifyr")
   fig_args <- c("run", fig_script, "-i", docx_out, "-o", docx_out)
 
-  if (!is.null(config_yaml)) {
-    fig_args <- c(fig_args, "-c", config_yaml)
-    log4r::info(.le$logger, paste0("config yaml set: ", config_yaml))
+  if (is.null(config_yaml)) {
+    config_yaml <- system.file("extdata", "config.yaml", package = "reportifyr")
   }
+  fig_args <- c(fig_args, "-c", config_yaml)
+  log4r::info(.le$logger, paste0("config yaml set: ", config_yaml))
 
   log4r::debug(.le$logger, "Running remove figures script")
   fig_result <- tryCatch(

--- a/R/save_rds_with_metadata.R
+++ b/R/save_rds_with_metadata.R
@@ -3,7 +3,7 @@
 #' @description Extension to the `saveRDS()` function that allows capturing object metadata as a separate `.json` file.
 #' @param object The `R` object to serialize.
 #' @param file The connection or name of the file where the `R` object is saved.
-#' @param config_yaml The path to the config.yaml, default is NULL and defaults will be used.
+#' @param config_yaml The file path to the `config.yaml`. Default is `NULL`. If `NULL`, a default value of `TRUE` for `save_rtf()` is used.
 #' @param meta_type A string to specify the type of object. Default is `"NA"`.
 #' @param meta_equations A string or vector of strings representing equations to include in the metadata. Default is `NULL`.
 #' @param meta_notes A string or vector of strings representing notes to include in the metadata. Default is `NULL`.

--- a/R/sync_report_project.R
+++ b/R/sync_report_project.R
@@ -5,8 +5,8 @@
 #' @param project_dir The file path to the main project directory
 #' where the directory structure will be created.
 #' The directory must already exist; otherwise, an error will be thrown.
-#' @param report_dir_name The directory name for where reports will be saved,
-#' default NULL will use "report"
+#' @param report_dir_name The directory name for where reports will be saved.
+#' Default is `NULL`. If `NULL`, `report` will be used.
 #'
 #' @export
 #'

--- a/R/validate_alt_text_magic_strings.R
+++ b/R/validate_alt_text_magic_strings.R
@@ -1,8 +1,7 @@
-#' validate_alt_text_magic_strings
+#' Validate alt text of figures/tables against their magic strings in a Microsoft Word file
 #'
-#' @param docx_in path to docx in file
-#' @param config_yaml path to config.yaml file
-#' @param debug boolean, whether to open browser
+#' @param docx_in The file path to the input `.docx` file.
+#' @param debug Debug.
 #'
 #' @export
 #'
@@ -11,7 +10,6 @@
 #' }
 validate_alt_text_magic_strings <- function(
   docx_in,
-  config_yaml = NULL,
   debug = FALSE
 ) {
   log4r::debug(.le$logger, "Starting validate_alt_text_magic_strings function")

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -1,8 +1,8 @@
-#' Validate config file
+#' Validate config.yaml file
 #'
-#' @param path_to_config_yaml path to config.yaml file
+#' @param path_to_config_yaml The file path to the `config.yaml`.
 #'
-#' @returns bool TRUE if config is valid, FALSE otherwise
+#' @returns bool `TRUE` if config is valid, `FALSE` otherwise.
 #' @export
 #'
 #' @examples \dontrun{

--- a/R/validate_docx.R
+++ b/R/validate_docx.R
@@ -1,6 +1,6 @@
-#' Validates input docx to ensure proper functionality with reportiryf
+#' Validates input Microsoft Word file to ensure proper functionality with reportifyr
 #'
-#' @param docx_in path to input docx
+#' @param docx_in The file path to the input `.docx` file.
 #' @param config_yaml The file path to the `config.yaml`.
 #'
 #' @export

--- a/R/validate_docx.R
+++ b/R/validate_docx.R
@@ -1,7 +1,7 @@
 #' Validates input docx to ensure proper functionality with reportiryf
 #'
 #' @param docx_in path to input docx
-#' @param config_yaml path to config.yaml file
+#' @param config_yaml The file path to the `config.yaml`.
 #'
 #' @export
 #'

--- a/R/validate_input_args.R
+++ b/R/validate_input_args.R
@@ -2,7 +2,6 @@
 #'
 #' @param docx_in input docx to work on
 #' @param docx_out output docx to save to
-#' @param config_yaml optional path to config yaml
 #'
 #' @return ()
 #' @internal
@@ -10,11 +9,10 @@
 #' @examples \dontrun{
 #' validate_input_args(
 #'   "template.docx",
-#'   "template-figs.docx",
-#'   "path/to/config.yaml"
+#'   "template-figs.docx"
 #' )
 #' }
-validate_input_args <- function(docx_in, docx_out, config_yaml = NULL) {
+validate_input_args <- function(docx_in, docx_out) {
   log4r::debug(.le$logger, "Starting validate_input_args function")
 
   if (!file.exists(docx_in)) {

--- a/R/validate_input_args.R
+++ b/R/validate_input_args.R
@@ -1,7 +1,7 @@
-#' validate_input_args
+#' Validates input and output arguments for reportifyr functions
 #'
-#' @param docx_in input docx to work on
-#' @param docx_out output docx to save to
+#' @param docx_in The file path to the input `.docx` file.
+#' @param docx_out The file path to the output `.docx` file to save to.
 #'
 #' @return ()
 #' @internal

--- a/R/write_csv_with_metadata.R
+++ b/R/write_csv_with_metadata.R
@@ -3,7 +3,7 @@
 #' @description Extension to the `write.csv()` function that allows capturing object metadata as a separate `.json` file.
 #' @param object The `R` object to serialize.
 #' @param file The connection or name of the file where the `R` object is saved.
-#' @param config_yaml The path to the config.yaml, default is NULL and defaults will be used.
+#' @param config_yaml The file path to the `config.yaml`. Default is `NULL`. If `NULL`, a default value of `TRUE` for `save_rtf()` is used.
 #' @param meta_type A string to specify the type of object. Default is `"NA"`.
 #' @param meta_equations A string or vector of strings representing equations to include in the metadata. Default is `NULL`.
 #' @param meta_notes A string or vector of strings representing notes to include in the metadata. Default is `NULL`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,12 +43,13 @@ library(reportifyr)
 
 Before starting any reporting effort, it is important to initialize all
 reporting directories within the project directory you are working in.
-Please note that for development, the directory structure and names have
-been hard-coded. We realize this is sub-optimal and are working on
-allowing user-defined `report` and `OUTPUTS` structure!
 
 ``` r
-initialize_report_project(project_dir = here::here())
+initialize_report_project(
+  project_dir = here::here(),
+  report_dir_name = "report",
+  outputs_dir_name = "OUTPUTS"
+)
 ```
 
 ## Steps at the Analysis Stage

--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ library(reportifyr)
 
 Before starting any reporting effort, it is important to initialize all
 reporting directories within the project directory you are working in.
-Please note that for development, the directory structure and names have
-been hard-coded. We realize this is sub-optimal and are working on
-allowing user-defined `report` and `OUTPUTS` structure!
 
 ``` r
-initialize_report_project(project_dir = here::here())
+initialize_report_project(
+  project_dir = here::here(),
+  report_dir_name = "report",
+  outputs_dir_name = "OUTPUTS"
+)
 ```
 
 ## Steps at the Analysis Stage

--- a/man/add_plots.Rd
+++ b/man/add_plots.Rd
@@ -21,7 +21,7 @@ add_plots(
 
 \item{figures_path}{The file path to the figures directory.}
 
-\item{config_yaml}{The path to config.yaml file that controls figure dimensions}
+\item{config_yaml}{The file path to the \code{config.yaml}. Default is \code{NULL}, a default \code{config.yaml} bundled with the \code{reportifyr} package is used.}
 
 \item{fig_width}{A global controller. The figure width in inches. Default is \code{NULL}. If \code{NULL}, the width is determined by the figure's pixel dimensions.}
 

--- a/man/add_plots_alt_text.Rd
+++ b/man/add_plots_alt_text.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/add_plots_alt_text.R
 \name{add_plots_alt_text}
 \alias{add_plots_alt_text}
-\title{add_plots_alt_text()}
+\title{Inserts alt text for figures within a Microsoft Word file.}
 \usage{
 add_plots_alt_text(docx_in, docx_out, debug = FALSE)
 }
 \arguments{
-\item{docx_in}{path to document}
+\item{docx_in}{The file path to the input \code{.docx} file.}
 
-\item{docx_out}{path to output document with figures alt text}
+\item{docx_out}{The file path to the output \code{.docx} file to save to.}
 
-\item{debug}{boolean turns on browser}
+\item{debug}{Debug.}
 }
 \description{
-add_plots_alt_text()
+Inserts alt text for figures within a Microsoft Word file.
 }
 \examples{
 \dontrun{

--- a/man/add_tables.Rd
+++ b/man/add_tables.Rd
@@ -13,7 +13,7 @@ add_tables(docx_in, docx_out, tables_path, config_yaml = NULL, debug = FALSE)
 
 \item{tables_path}{The file path to the tables and associated metadata directory.}
 
-\item{config_yaml}{The path to config.yaml file that controls figure dimensions}
+\item{config_yaml}{The file path to the \code{config.yaml}. Default is \code{NULL}, a default \code{config.yaml} bundled with the \code{reportifyr} package is used.}
 
 \item{debug}{Debug.}
 }

--- a/man/add_tables_alt_text.Rd
+++ b/man/add_tables_alt_text.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/add_tables_alt_text.R
 \name{add_tables_alt_text}
 \alias{add_tables_alt_text}
-\title{add_tables_alt_text}
+\title{Inserts alt text for tables within a Microsoft Word file.}
 \usage{
 add_tables_alt_text(docx_in, docx_out, debug = FALSE)
 }
 \arguments{
-\item{docx_in}{path to input document}
+\item{docx_in}{The file path to the input \code{.docx} file.}
 
-\item{docx_out}{path to output document}
+\item{docx_out}{The file path to the output \code{.docx} file to save to.}
 
-\item{debug}{boolean for turning on debugging}
+\item{debug}{Debug.}
 }
 \description{
-add_tables_alt_text
+Inserts alt text for tables within a Microsoft Word file.
 }
 \examples{
 \dontrun{

--- a/man/finalize_document.Rd
+++ b/man/finalize_document.Rd
@@ -4,14 +4,14 @@
 \alias{finalize_document}
 \title{Finalizes the Microsoft Word file by removing magic strings and bookmarks}
 \usage{
-finalize_document(docx_in, docx_out = NULL, config_yaml)
+finalize_document(docx_in, docx_out = NULL, config_yaml = NULL)
 }
 \arguments{
 \item{docx_in}{The file path to the input \code{.docx} file.}
 
 \item{docx_out}{The file path to the output \code{.docx} file to save to. Default is \code{NULL}. If \code{NULL}, \code{docx_out} is assigned \code{doc_dirs$doc_final} using \code{make_doc_dirs(docx_in = docx_in)}.}
 
-\item{config_yaml}{The file path to the \code{config.yaml}.}
+\item{config_yaml}{The file path to the \code{config.yaml}. Default is \code{NULL}, a default \code{config.yaml} bundled with the \code{reportifyr} package is used.}
 }
 \description{
 Reads in a \code{.docx} file and returns a finalized version with magic strings and bookmarks removed.

--- a/man/initialize_report_project.Rd
+++ b/man/initialize_report_project.Rd
@@ -15,11 +15,11 @@ initialize_report_project(
 where the directory structure will be created.
 The directory must already exist; otherwise, an error will be thrown.}
 
-\item{report_dir_name}{The directory name for where reports will be saved,
-default NULL will use "report"}
+\item{report_dir_name}{The directory name for where reports will be saved.
+Default is \code{NULL}. If \code{NULL}, \code{report} will be used.}
 
-\item{outputs_dir_name}{The directory name for where artifacts will be saved,
-default NULL will use "OUTPUTS"}
+\item{outputs_dir_name}{The directory name for where artifacts will be saved.
+Default is \code{NULL}. If \code{NULL}, \code{OUTPUTS} will be used.}
 }
 \description{
 Create report directories within a project

--- a/man/save_rds_with_metadata.Rd
+++ b/man/save_rds_with_metadata.Rd
@@ -21,7 +21,7 @@ save_rds_with_metadata(
 
 \item{file}{The connection or name of the file where the \code{R} object is saved.}
 
-\item{config_yaml}{The path to the config.yaml, default is NULL and defaults will be used.}
+\item{config_yaml}{The file path to the \code{config.yaml}. Default is \code{NULL}. If \code{NULL}, a default value of \code{TRUE} for \code{save_rtf()} is used.}
 
 \item{meta_type}{A string to specify the type of object. Default is \code{"NA"}.}
 

--- a/man/sync_report_project.Rd
+++ b/man/sync_report_project.Rd
@@ -13,8 +13,8 @@ sync_report_project(project_dir, report_dir_name = NULL)
 where the directory structure will be created.
 The directory must already exist; otherwise, an error will be thrown.}
 
-\item{report_dir_name}{The directory name for where reports will be saved,
-default NULL will use "report"}
+\item{report_dir_name}{The directory name for where reports will be saved.
+Default is \code{NULL}. If \code{NULL}, \code{report} will be used.}
 }
 \description{
 Synchronizes report project with config and python

--- a/man/validate_alt_text_magic_strings.Rd
+++ b/man/validate_alt_text_magic_strings.Rd
@@ -2,19 +2,17 @@
 % Please edit documentation in R/validate_alt_text_magic_strings.R
 \name{validate_alt_text_magic_strings}
 \alias{validate_alt_text_magic_strings}
-\title{validate_alt_text_magic_strings}
+\title{Validate alt text of figures/tables against their magic strings in a Microsoft Word file}
 \usage{
-validate_alt_text_magic_strings(docx_in, config_yaml = NULL, debug = FALSE)
+validate_alt_text_magic_strings(docx_in, debug = FALSE)
 }
 \arguments{
-\item{docx_in}{path to docx in file}
+\item{docx_in}{The file path to the input \code{.docx} file.}
 
-\item{config_yaml}{path to config.yaml file}
-
-\item{debug}{boolean, whether to open browser}
+\item{debug}{Debug.}
 }
 \description{
-validate_alt_text_magic_strings
+Validate alt text of figures/tables against their magic strings in a Microsoft Word file
 }
 \examples{
 \dontrun{

--- a/man/validate_config.Rd
+++ b/man/validate_config.Rd
@@ -2,18 +2,18 @@
 % Please edit documentation in R/validate_config.R
 \name{validate_config}
 \alias{validate_config}
-\title{Validate config file}
+\title{Validate config.yaml file}
 \usage{
 validate_config(path_to_config_yaml)
 }
 \arguments{
-\item{path_to_config_yaml}{path to config.yaml file}
+\item{path_to_config_yaml}{The file path to the \code{config.yaml}.}
 }
 \value{
-bool TRUE if config is valid, FALSE otherwise
+bool \code{TRUE} if config is valid, \code{FALSE} otherwise.
 }
 \description{
-Validate config file
+Validate config.yaml file
 }
 \examples{
 \dontrun{

--- a/man/validate_docx.Rd
+++ b/man/validate_docx.Rd
@@ -2,17 +2,17 @@
 % Please edit documentation in R/validate_docx.R
 \name{validate_docx}
 \alias{validate_docx}
-\title{Validates input docx to ensure proper functionality with reportiryf}
+\title{Validates input Microsoft Word file to ensure proper functionality with reportifyr}
 \usage{
 validate_docx(docx_in, config_yaml)
 }
 \arguments{
-\item{docx_in}{path to input docx}
+\item{docx_in}{The file path to the input \code{.docx} file.}
 
-\item{config_yaml}{path to config.yaml file}
+\item{config_yaml}{The file path to the \code{config.yaml}.}
 }
 \description{
-Validates input docx to ensure proper functionality with reportiryf
+Validates input Microsoft Word file to ensure proper functionality with reportifyr
 }
 \examples{
 \dontrun{

--- a/man/validate_input_args.Rd
+++ b/man/validate_input_args.Rd
@@ -2,29 +2,26 @@
 % Please edit documentation in R/validate_input_args.R
 \name{validate_input_args}
 \alias{validate_input_args}
-\title{validate_input_args}
+\title{Validates input and output arguments for reportifyr functions}
 \usage{
-validate_input_args(docx_in, docx_out, config_yaml = NULL)
+validate_input_args(docx_in, docx_out)
 }
 \arguments{
-\item{docx_in}{input docx to work on}
+\item{docx_in}{The file path to the input \code{.docx} file.}
 
-\item{docx_out}{output docx to save to}
-
-\item{config_yaml}{optional path to config yaml}
+\item{docx_out}{The file path to the output \code{.docx} file to save to.}
 }
 \value{
 ()
 }
 \description{
-validate_input_args
+Validates input and output arguments for reportifyr functions
 }
 \examples{
 \dontrun{
 validate_input_args(
   "template.docx",
-  "template-figs.docx",
-  "path/to/config.yaml"
+  "template-figs.docx"
 )
 }
 }

--- a/man/write_csv_with_metadata.Rd
+++ b/man/write_csv_with_metadata.Rd
@@ -21,7 +21,7 @@ write_csv_with_metadata(
 
 \item{file}{The connection or name of the file where the \code{R} object is saved.}
 
-\item{config_yaml}{The path to the config.yaml, default is NULL and defaults will be used.}
+\item{config_yaml}{The file path to the \code{config.yaml}. Default is \code{NULL}. If \code{NULL}, a default value of \code{TRUE} for \code{save_rtf()} is used.}
 
 \item{meta_type}{A string to specify the type of object. Default is \code{"NA"}.}
 


### PR DESCRIPTION
- If `config_yaml` is left `NULL` for the following functions, a default `config.yaml` file bundled with `reportifyr` is used instead:
  * `add_footnotes()`
  * `add_plots()`
  * `add_tables()`
  * `build_report()`
  * `finalize_document()`
  * `remove_tables_figures_footnotes()`

- `validate_input_args()` and `validate_alt_text_magic_strings()` no longer take a `config_yaml` argument.

- Function and argument descriptions introduced or expanded on in 0.3.0 have been updated for clarity and understanding.