### PR TITLE
Argus

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -78,15 +78,6 @@ jobs:
             echo "All system dependencies are present"
           fi
 
-      - name: rv-sysdeps-install (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install gettext
-          prefix=$(brew --prefix gettext)
-          echo "LDFLAGS=-L${prefix}/lib $LDFLAGS" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I${prefix}/include $CPPFLAGS" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-
       - name: rv-sync
         run: rv sync
         if: runner.os != 'Windows'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -78,6 +78,15 @@ jobs:
             echo "All system dependencies are present"
           fi
 
+      - name: rv-sysdeps-install (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install gettext
+          prefix=$(brew --prefix gettext)
+          echo "LDFLAGS=-L${prefix}/lib $LDFLAGS" >> $GITHUB_ENV
+          echo "CPPFLAGS=-I${prefix}/include $CPPFLAGS" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=${prefix}/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+
       - name: rv-sync
         run: rv sync
         if: runner.os != 'Windows'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: reportifyr
 Title: Reproducible Reporting Made Simple with R
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: c(
     person("Jacob", "Dumbleton", , "jacob@a2-ai.com", role = c("aut", "cre")),
     person("Matthew", "Smith", , "matthews@a2-ai.com", role = "aut"),
@@ -39,7 +39,6 @@ Imports:
     processx,
     purrr,
     rlang,
-    rstudioapi,
     this.path,
     tictoc,
     yaml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Imports:
     purrr,
     rlang,
     rstudioapi,
+    this.path,
     tictoc,
     yaml
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# reportifyr 0.3.3
+## Bug Fixes
+
+* Fixed an issue where the source path of an object being written out with `write_object_metadata()` during a quarto render was being captured as the intermediate `.rmarkdown`.
+
 # reportifyr 0.3.2
 ## Improvements
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -241,11 +241,7 @@ detect_quarto_render <- function() {
   # --- Detect Quarto context ---
   quarto_vars <- Sys.getenv(c("QUARTO_PROJECT_ROOT", "QUARTO_BIN_PATH", "QUARTO_RENDER_TOKEN"))
   is_quarto <- any(quarto_vars != "")
-  log4r::debug(.le$logger, paste0(
-    "Quarto vars: ",
-    paste(names(quarto_vars), quarto_vars, sep = "=", collapse = "; "),
-    " | is_quarto = ", is_quarto
-  ))
+  log4r::debug(.le$logger, paste0("Quarto environment vars detected: ", is_quarto))
 
   if (!is_quarto) {
     log4r::debug(.le$logger, "Not running in a Quarto context, returning NULL")

--- a/R/utils.R
+++ b/R/utils.R
@@ -248,7 +248,7 @@ detect_quarto_render <- function() {
   ))
 
   if (!is_quarto) {
-    log4r::debug(.le$logger, "Not running in a Quarto context — returning NULL")
+    log4r::debug(.le$logger, "Not running in a Quarto context, returning NULL")
     return(NULL)
   }
 
@@ -258,7 +258,7 @@ detect_quarto_render <- function() {
 
   # --- Validate current file pattern ---
   if (is.null(current) || !grepl("\\.(Rmd|rmarkdown)$", current, ignore.case = TRUE)) {
-    log4r::debug(.le$logger, "Current input is NULL or not an .Rmd/.rmarkdown file — returning NULL")
+    log4r::debug(.le$logger, "Current input is NULL or not an .Rmd/.rmarkdown file, returning NULL")
     return(NULL)
   }
 
@@ -277,7 +277,7 @@ detect_quarto_render <- function() {
   } else {
     log4r::warn(.le$logger, paste0(
       "Quarto environment detected, but .qmd not found at: ", qmd_path,
-      " — returning NULL"
+      ", returning NULL"
     ))
     return(NULL)
   }

--- a/rproject.toml
+++ b/rproject.toml
@@ -7,9 +7,11 @@ r_version = "4.4"
 repositories = [
 	#{ alias = "PRISM", url = "https://prism.dev.a2-ai.cloud/rpkgs/stratus/2025-07-28/" },
 	{alias = "ppm", url = "https://packagemanager.posit.co/cran/latest"},
+	{alias = "CRAN", url = "https://cran.r-project.org"},
 ]
 
 dependencies = [
 	"devtools",
 	{name = "reportifyr", path = ".", dependencies_only = true, install_suggestions = true },
+	{name = "gdtools", repository = "CRAN"},
 ]


### PR DESCRIPTION
- Fixed an issue where the source path of an object being written out with `write_object_metadata()` during a quarto render was being captured as the intermediate `.rmarkdown`.

Input `.qmd`:

```
---
title: "Metadata Test"
format: html
execute:
  warning: false
  message: false
---
```
```r
library(reportifyr)

# Create a simple CSV table
table_file <-"test-table.csv"

# Generate simple data
test_data <- data.frame(
  id = 1:5,
  value = c(10, 20, 30, 40, 50),
  category = c("A", "B", "A", "B", "A")
)

write.csv(test_data, table_file, row.names = FALSE)

# Write metadata
reportifyr::write_object_metadata(object_file = table_file)
```

Before:
<img width="410" height="130" alt="Screenshot 2025-10-19 at 7 05 31 PM" src="https://github.com/user-attachments/assets/a2c73e5a-817f-4d08-814a-358908f4bc51" />

After: 
<img width="415" height="155" alt="Screenshot 2025-10-19 at 7 18 39 PM" src="https://github.com/user-attachments/assets/ba9b00ce-8fda-4cfd-b140-550f435a6185" />
