### PR TITLE
use table_name

### DIFF
--- a/R/add_tables.R
+++ b/R/add_tables.R
@@ -100,7 +100,8 @@ add_tables <- function(
         if (!(table_file %in% processed_files)) {
           document <- process_table_file(
             table_file,
-            document
+            document,
+            table_name
           )
           processed_files <- c(processed_files, table_file)
         } else {
@@ -137,7 +138,7 @@ add_tables <- function(
 }
 
 ### New function for processing #####
-process_table_file <- function(table_file, document) {
+process_table_file <- function(table_file, document, table_name) {
   log4r::info(
     .le$logger,
     paste0("Processing table file: ", table_file)
@@ -189,7 +190,7 @@ process_table_file <- function(table_file, document) {
 
   document <- officer::cursor_reach(
     document,
-    paste0("\\{rpfy\\}:", basename(table_file))
+    paste0("\\{rpfy\\}:", table_name)
   )
 
   flextable::body_add_flextable(

--- a/inst/scripts/add_figure.py
+++ b/inst/scripts/add_figure.py
@@ -71,7 +71,7 @@ def add_figure(
                         add_label = True
 
                     found_magic_strings.append(figure)
-                    image_path = os.path.join(figure_dir, figure)
+                    image_path = os.path.normpath(os.path.join(figure_dir, figure))
                     if os.path.exists(image_path):
                         if add_label:
                             # since list is reversed need to use correct

--- a/inst/scripts/add_figure.py
+++ b/inst/scripts/add_figure.py
@@ -71,7 +71,7 @@ def add_figure(
                         add_label = True
 
                     found_magic_strings.append(figure)
-                    image_path = os.path.normpath(os.path.join(figure_dir, figure))
+                    image_path = os.path.join(figure_dir, figure)
                     if os.path.exists(image_path):
                         if add_label:
                             # since list is reversed need to use correct

--- a/inst/scripts/add_figure_footnotes.py
+++ b/inst/scripts/add_figure_footnotes.py
@@ -53,9 +53,7 @@ def add_figure_footnotes(
             # enumerating here so i can use f to get label for
             # helper.create_label(f)
             for f, figure_name in enumerate(figure_args.keys()):
-                figure_path = os.path.normpath(os.path.join(figure_dir, figure_name))
-                
-                if os.path.exists(figure_path):
+                if figure_name in os.listdir(figure_dir):
                     metadata = helper.load_metadata(figure_dir, figure_name)
 
                     if metadata is not None:

--- a/inst/scripts/add_figure_footnotes.py
+++ b/inst/scripts/add_figure_footnotes.py
@@ -53,8 +53,13 @@ def add_figure_footnotes(
             # enumerating here so i can use f to get label for
             # helper.create_label(f)
             for f, figure_name in enumerate(figure_args.keys()):
-                if figure_name in os.listdir(figure_dir):
-                    metadata = helper.load_metadata(figure_dir, figure_name)
+                figure_path = os.path.normpath(os.path.join(figure_dir, figure_name))
+                
+                if os.path.exists(figure_path):
+                    metadata = helper.load_metadata(
+                        os.path.dirname(figure_path),
+                        os.path.basename(figure_path)
+                    )
 
                     if metadata is not None:
                         meta_text_dict = helper.create_meta_text_lines(

--- a/inst/scripts/add_figure_footnotes.py
+++ b/inst/scripts/add_figure_footnotes.py
@@ -53,7 +53,9 @@ def add_figure_footnotes(
             # enumerating here so i can use f to get label for
             # helper.create_label(f)
             for f, figure_name in enumerate(figure_args.keys()):
-                if figure_name in os.listdir(figure_dir):
+                figure_path = os.path.normpath(os.path.join(figure_dir, figure_name))
+                
+                if os.path.exists(figure_path):
                     metadata = helper.load_metadata(figure_dir, figure_name)
 
                     if metadata is not None:

--- a/inst/scripts/add_table_footnotes.py
+++ b/inst/scripts/add_table_footnotes.py
@@ -48,9 +48,8 @@ def add_table_footnotes(
         for match in matches:
             # Generalized extraction of the table name
             table_name = match.replace("{rpfy}:", "").strip()
-            
-            table_path = os.path.normpath(os.path.join(table_dir, table_name))
-            if os.path.exists(table_path):
+
+            if table_name in os.listdir(table_dir):
                 metadata = helper.load_metadata(table_dir, table_name)
 
                 add_footnote = False

--- a/inst/scripts/add_table_footnotes.py
+++ b/inst/scripts/add_table_footnotes.py
@@ -48,8 +48,9 @@ def add_table_footnotes(
         for match in matches:
             # Generalized extraction of the table name
             table_name = match.replace("{rpfy}:", "").strip()
-
-            if table_name in os.listdir(table_dir):
+            
+            table_path = os.path.normpath(os.path.join(table_dir, table_name))
+            if os.path.exists(table_path):
                 metadata = helper.load_metadata(table_dir, table_name)
 
                 add_footnote = False

--- a/inst/scripts/add_table_footnotes.py
+++ b/inst/scripts/add_table_footnotes.py
@@ -48,9 +48,13 @@ def add_table_footnotes(
         for match in matches:
             # Generalized extraction of the table name
             table_name = match.replace("{rpfy}:", "").strip()
+            table_path = os.path.normpath(os.path.join(table_dir, table_name))
 
-            if table_name in os.listdir(table_dir):
-                metadata = helper.load_metadata(table_dir, table_name)
+            if os.path.exists(table_path):
+                metadata = helper.load_metadata(
+                    os.path.dirname(table_path),
+                    os.path.basename(table_path)
+                )
 
                 add_footnote = False
                 if metadata is None:


### PR DESCRIPTION
- Added support for stratifying `OUTPUTS/figures` and `OUTPUTS/tables` into subdirectories. User points to the parent directory in the function call, while the magic string in the `.docx` is relative to the parent directory. 

`add_tables()` input `.docx` file:

<img width="430" height="110" alt="Screenshot 2026-01-12 at 11 24 41 AM" src="https://github.com/user-attachments/assets/00260baa-cc82-4145-8fe5-91a140704e6c" />

Before:

```r
> library(reportifyr)

> initialize_report_project(
+   project_dir = here::here(),
+   report_dir_name = NULL,
+   outputs_dir_name = NULL
+ )

reportifyr has already been initialized. Syncing with config file now.
Nothing to do

> module_dir <- here::here("scripts", "02_add_tables")
> tables_path  <- here::here("OUTPUTS", "tables")
> config <- here::here("report", "config.yaml")

> file.exists(... = "OUTPUTS/tables/DEC1/theoph-pk-parameters.csv")
[1] TRUE

> reportifyr::add_tables(
+     docx_in = file.path(module_dir, "template.docx"),
+     docx_out = file.path(module_dir, "template-tabs.docx"),
+     tables_path = tables_path,
+     config_yaml = config,
+     debug = FALSE
+ )

Error: \{rpfy\}:theoph-pk-parameters.csv has not been found in the document
```

<img width="1070" height="67" alt="Screenshot 2026-01-12 at 11 31 04 AM" src="https://github.com/user-attachments/assets/0039a63f-b6fb-49da-af72-174e66d1f6e6" />

After:

```r
> library(reportifyr)

> initialize_report_project(
+   project_dir = here::here(),
+   report_dir_name = NULL,
+   outputs_dir_name = NULL
+ )

reportifyr has already been initialized. Syncing with config file now.
Nothing to do

> module_dir <- here::here("scripts", "02_add_tables")
> tables_path  <- here::here("OUTPUTS", "tables")
> config <- here::here("report", "config.yaml")

> file.exists(... = "OUTPUTS/tables/DEC1/theoph-pk-parameters.csv")
[1] TRUE

> reportifyr::add_tables(
+     docx_in = file.path(module_dir, "template.docx"),
+     docx_out = file.path(module_dir, "template-tabs.docx"),
+     tables_path = tables_path,
+     config_yaml = config,
+     debug = FALSE
+ )

0.497 sec elapsed
4.286 sec elapsed
```

<img width="930" height="460" alt="Screenshot 2026-01-12 at 11 54 08 AM" src="https://github.com/user-attachments/assets/e6189dcb-2c2b-4873-b196-27f1676e217d" />

`add_footnotes()` input `.docx` file:

<img width="972" height="1138" alt="Screenshot 2026-01-12 at 4 35 11 PM" src="https://github.com/user-attachments/assets/fedd7014-40ad-48ce-aadf-f41c74418ffe" />

Before: 

```r
> library(reportifyr)

> initialize_report_project(
+   project_dir = here::here(),
+   report_dir_name = NULL,
+   outputs_dir_name = NULL
+ )

reportifyr has already been initialized. Syncing with config file now.
Nothing to do

> module_dir <- here::here("scripts", "02_add_tables")
> tables_path  <- here::here("OUTPUTS", "tables")
> standard_footnotes <- here::here("report", "standard_footnotes.yaml")
> config <- here::here("report", "config.yaml")

> add_footnotes(
+   docx_in = file.path(module_dir, "template.docx"),
+   docx_out = file.path(module_dir, "template-draft.docx"),
+   figures_path = figures_path,
+   tables_path = tables_path,
+   standard_footnotes_yaml = standard_footnotes,
+   config_yaml = config,
+   include_object_path = FALSE,
+   footnotes_fail_on_missing_metadata = TRUE,
+   debug = FALSE
+ )
1.915 sec elapsed
```

Appears to be a silent failure as output `.docx` is:

<img width="963" height="1149" alt="Screenshot 2026-01-12 at 4 40 25 PM" src="https://github.com/user-attachments/assets/a9ed5ff8-0c88-4636-aa97-adf2a8bd9380" />

After:

```r
> library(reportifyr)

> initialize_report_project(
+   project_dir = here::here(),
+   report_dir_name = NULL,
+   outputs_dir_name = NULL
+ )

reportifyr has already been initialized. Syncing with config file now.
Nothing to do

> module_dir <- here::here("scripts", "02_add_tables")
> tables_path  <- here::here("OUTPUTS", "tables")
> standard_footnotes <- here::here("report", "standard_footnotes.yaml")
> config <- here::here("report", "config.yaml")

> add_footnotes(
+   docx_in = file.path(module_dir, "template.docx"),
+   docx_out = file.path(module_dir, "template-draft.docx"),
+   figures_path = figures_path,
+   tables_path = tables_path,
+   standard_footnotes_yaml = standard_footnotes,
+   config_yaml = config,
+   include_object_path = FALSE,
+   footnotes_fail_on_missing_metadata = TRUE,
+   debug = FALSE
+ )
1.037 sec elapsed
```

Actual success as output `.docx` is:

<img width="941" height="614" alt="Screenshot 2026-01-12 at 4 43 09 PM" src="https://github.com/user-attachments/assets/ef4c329f-c2c9-4d9b-87a7-c21a3e0e4644" />

<img width="930" height="846" alt="Screenshot 2026-01-12 at 4 36 39 PM" src="https://github.com/user-attachments/assets/7449722a-38e4-495e-930b-4421ced2abf1" />
